### PR TITLE
Added missing hyphen in german translation

### DIFF
--- a/tools/l10n/robotranslations/locales_sample.yaml
+++ b/tools/l10n/robotranslations/locales_sample.yaml
@@ -30,7 +30,7 @@ de:
     - Turbo-Modus
     - Der Turbo-Modus hilft Ihnen, schneller zu surfen
     - Der Turbo-Modus blockiert automatisch Tracker und Anzeigen, damit Sie schneller ans Ziel kommen. Wenn es einen Geschwindigkeitsschub gibt - wie bei einer Website, die sich nicht so verhält, wie Sie es erwarten - schalten Sie einfach den Turbo-Modus aus.
-    - Turbo Modus aktiviert lassen
+    - Turbo-Modus aktiviert lassen
     - Turbo-Modus deaktivieren
 
 hi-rIN:


### PR DESCRIPTION
Changed text from #455 was missing an hyphen, which is used in all other texts.